### PR TITLE
bumping version constant to v0.5.0

### DIFF
--- a/tldr.go
+++ b/tldr.go
@@ -40,7 +40,7 @@ type Bag struct {
 
 // The default values of each settings
 const (
-	VERSION                              = "0.4.4"
+	VERSION                              = "0.5.0"
 	DEFAULT_ALGORITHM                    = "pagerank"
 	DEFAULT_WEIGHING                     = "hamming"
 	DEFAULT_DAMPING                      = 0.85


### PR DESCRIPTION
Nothing's changed. Only bumping the version to create new tag so glide and other vendoring tools will pick the newest version.